### PR TITLE
Less Speed for FreeplayState.hx

### DIFF
--- a/src/funkin/states/FreeplayMenu.hx
+++ b/src/funkin/states/FreeplayMenu.hx
@@ -206,7 +206,8 @@ class FreeplayMenu extends FunkinState {
 		if(!defaultBehavior) return;
 		speedTimer += FlxG.elapsed;
 		if ((Controls.getP("ui_left") || Controls.getP("ui_right")) || speedTimer > 0.5) {
-			curSpeed = FlxMath.bound(FlxMath.roundDecimal(curSpeed + mult, 2), 0.05, 10);
+			// overrated 10x thingy, what is a point of it if there is 5x
+			curSpeed = FlxMath.bound(FlxMath.roundDecimal(curSpeed + mult, 2), 0.5, 10);
 			FlxG.sound.music.pitch = curSpeed;
 			if(speedTimer > 0.5) speedTimer = 0.425;
 		}


### PR DESCRIPTION
- no more hour-long songs! no more 0.05 speed! and no MORE breaking Flixel limits!
- Removed anything below than 0.5 speed (do I need to explain? its a bloater and creates fucking hour songs.)

this engine actually slaps harder than I thought.